### PR TITLE
Handle multiple entries in GOPATH

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -2,14 +2,15 @@
 machine:
   environment:
     IMPORT_PATH: "github.com/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME"
+    MYGOPATH: "$(echo $GOPATH | cut -d : -f 1)"
 
 dependencies:
   pre:
     - go get github.com/tools/godep
 
   override:
-    - mkdir -p "$GOPATH/src/$IMPORT_PATH"
-    - rsync -azC --delete ./ "$GOPATH/src/$IMPORT_PATH/"
+    - mkdir -p "$MYGOPATH/src/$IMPORT_PATH"
+    - rsync -azC --delete ./ "$MYGOPATH/src/$IMPORT_PATH/"
 
 test:
   pre:


### PR DESCRIPTION
Circle's $GOPATH includes two paths for new projects. Split on `:` and use the
first for our copy of the source code into the $GOPATH.