### PR TITLE
Check for Godeps.json before restoring

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -5,5 +5,5 @@ set -e
 # Install godep
 go get github.com/tools/godep
 
-# Restore dependencies from Godeps
-godep restore
+# Restore dependencies from Godeps if they exist
+[[ -f ./Godeps/Godeps.json ]] && godep restore


### PR DESCRIPTION
- `godep restore` fails if there's no `Godeps.json`
- It doesn't make sense to run `godeps restore` if there are no existing
  dependencies listed.