### PR TITLE
Do not vet vendored dependencies

### DIFF
--- a/bin/vet
+++ b/bin/vet
@@ -20,7 +20,7 @@ function checkfmt() {
 }
 
 function checkvet() {
-  unvetted=$(go vet ./... 2>&1 | grep -v "exit status")
+  unvetted=$(go vet $(go list ./... | grep -v /vendor/) 2>&1 | grep -v "exit status")
   [ -z "$unvetted" ] && return 0
 
   echo >&2 "Go files must be vetted. Check these problems:"


### PR DESCRIPTION
- `bin/vet` was overly aggressive, vetting dependencies and failing