### PR TITLE
Improve vet script

### DIFF
--- a/bin/vet
+++ b/bin/vet
@@ -4,16 +4,16 @@
 # symlink as .git/hooks/pre-commit to use as a pre-commit check.
 #
 
-gofiles=$(find . ! -path "*/_*" -name "*.go")
-[ -z "$gofiles" ] && exit 0
-
 function checkfmt() {
-  unformatted=$(gofmt -l $*)
+  gofiles=$(find . ! -path "*/_*" -name "*.go" | grep -Fv "./vendor/")
+  [ -z "$gofiles" ] && return 0
+
+  unformatted=$(gofmt -l $gofiles)
   [ -z "$unformatted" ] && return 0
 
   echo >&2 "Go files must be formatted with gofmt. Please run:"
-  for fn in $unformatted; do
-    echo >&2 "  gofmt -w $PWD/$fn"
+  for filename in $unformatted; do
+    echo >&2 "  gofmt -w $filename"
   done
 
   return 1
@@ -33,7 +33,7 @@ function checkvet() {
   return 1
 }
 
-checkfmt $gofiles || fail=yes
-checkvet $gofiles || fail=yes
+checkfmt || fail=yes
+checkvet || fail=yes
 
 [ -z "$fail" ] || exit 1

--- a/circle.yml
+++ b/circle.yml
@@ -14,7 +14,7 @@ dependencies:
 
 test:
   pre:
-    - bin/vet
+    - cd $MYGOPATH/src/$IMPORT_PATH && bin/vet
 
   override:
     - godep go test ./...


### PR DESCRIPTION
`gofiles` variable was only used in one of the functions, so move it in
there instead of passing it in.

Use `basename $filename` to remove the `/./` path element in the output.

On CI, `bin/vet` was running from the directory right in the home.
Because of this `go list ./...` couldn't find valid package names.

Since we create a Go-friendly directory structure on CI, we can run
`bin/vet` from there to get a good list of packages to vet.